### PR TITLE
[Improvement]#33 이메일 인증 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "chai": "^4.3.8",
         "chai-http": "^4.4.0",
         "child_process": "^1.0.2",
+        "connect-redis": "^7.1.0",
         "cookie-parser": "^1.4.6",
         "cors": "^2.8.5",
         "dotenv": "^16.0.3",
@@ -1932,6 +1933,17 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+    },
+    "node_modules/connect-redis": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/connect-redis/-/connect-redis-7.1.0.tgz",
+      "integrity": "sha512-UaqO1EirWjON2ENsyau7N5lbkrdYBpS6mYlXSeff/OYXsd6EGZ+SXSmNPoljL2PSua8fgjAEaldSA73PMZQ9Eg==",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "express-session": ">=1"
+      }
     },
     "node_modules/console-control-strings": {
       "version": "1.1.0",
@@ -6445,6 +6457,12 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+    },
+    "connect-redis": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/connect-redis/-/connect-redis-7.1.0.tgz",
+      "integrity": "sha512-UaqO1EirWjON2ENsyau7N5lbkrdYBpS6mYlXSeff/OYXsd6EGZ+SXSmNPoljL2PSua8fgjAEaldSA73PMZQ9Eg==",
+      "requires": {}
     },
     "console-control-strings": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "chai": "^4.3.8",
     "chai-http": "^4.4.0",
     "child_process": "^1.0.2",
+    "connect-redis": "^7.1.0",
     "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
     "dotenv": "^16.0.3",

--- a/src/api/middlewares/errorHandler.js
+++ b/src/api/middlewares/errorHandler.js
@@ -24,9 +24,7 @@ const errorHandler = (err, req, res, next) => {
       return res.status(customError.statusCode).json({ errMessage: customError.errMessage });
     } else {
       console.log('커스텀에러');
-      logger.error(
-        `res : ${req.ip}, ${StatusCodes.INTERNAL_SERVER_ERROR} : ${err.name} - ${err.message}, Stack: ${err.stack}`,
-      );
+      logger.error(`res : ${req.ip}, ${customError.statusCode} : ${err.name} - ${err.message}, Stack: ${err.stack}`);
 
       return res.status(customError.statusCode).json({ errMessage: customError.errMessage });
     }

--- a/src/api/routes/auth.route.js
+++ b/src/api/routes/auth.route.js
@@ -3,9 +3,10 @@ const { authController, userController } = require('../../controllers');
 const { asyncWrap } = require('../middlewares/async');
 const router = express.Router();
 
-router.route('/kakao/oauth').get(asyncWrap(authController.kakaoLoginCallback));
+router.route('/kakao/oauth').get(asyncWrap(authController.kakaoGetData));
 router.route('/auth-email').get(asyncWrap(authController.authEmail));
 router.route('/login').get(asyncWrap(authController.loginByEmail));
+
 // 텍스트 처리 후 스포티파이 썸네일 검색
 // http://localhost:3306/api/auth/spotify/callback
 

--- a/src/api/routes/auth.route.js
+++ b/src/api/routes/auth.route.js
@@ -4,7 +4,7 @@ const { asyncWrap } = require('../middlewares/async');
 const router = express.Router();
 
 router.route('/kakao/oauth').get(asyncWrap(authController.kakaoGetData));
-router.route('/auth-email').get(asyncWrap(authController.authEmail));
+router.route('/auth-email').post(asyncWrap(authController.authEmail));
 router.route('/login').get(asyncWrap(authController.loginByEmail));
 
 // 텍스트 처리 후 스포티파이 썸네일 검색

--- a/src/app.js
+++ b/src/app.js
@@ -34,7 +34,6 @@ redisClient.clientConnect();
 
 app.use(
   session({
-    cookie: { maxAge: 86400000, secure: false },
     store: new RedisStore({ client: redisClient.getClient() }),
     resave: false,
     secret: 'keyboard cat',

--- a/src/app.js
+++ b/src/app.js
@@ -35,15 +35,43 @@ redisClient.clientConnect();
 app.use(
   session({
     store: new RedisStore({ client: redisClient.getClient() }),
-    resave: false,
+    resave: true, // 변경사항 발생 시 만료 시간 갱신
+    rolling: true, // 클라이언트 요청 시 만료 시간 갱신
     secret: 'keyboard cat',
     saveUninitialized: false,
+    cookie: {
+      maxAge: 30 * 60 * 1000, // 만료시간 30분 설정
+    },
   }),
 );
-
 // passport-> 세션 설정 후 미들웨어 등록
 app.use(passport.initialize());
 app.use(passport.session());
+
+// 세션 사용 위한 테스트
+// app.post('/test', (req, res) => {
+//   const data = req.body;
+//   // 사용자 인증 로직...
+//   if (data) {
+//     // 사용자 인증 성공 시, 세션에 정보 저장
+//     req.session.userId = data.email;
+//     res.send('Logged in!');
+//   } else {
+//     res.send('Authentication failed');
+//   }
+// });
+
+// app.get('/test2', (req, res) => {
+//   console.log(req.session);
+//   if (req.session.userId) {
+//     // 세션에서 userId 가져오기
+//     const userId = req.session.userId;
+//     // userId를 사용하여 필요한 작업 수행
+//     res.send(`User ID is: ${userId}`);
+//   } else {
+//     res.send('You are not logged in!');
+//   }
+// });
 
 app.use('/api', route);
 app.use(errorHandler);

--- a/src/constants/strings.js
+++ b/src/constants/strings.js
@@ -3,7 +3,7 @@ const ALERT = {
   CHECK_INPUT_DATA: `입력하신 정보가 옳바르지 않습니다. 확인하여 다시 입력해주세요.`, // 409
   RETRY_REQ: `네트워크가 불안정합니다. 잠시 후 다시 시도해주세요.`, // 500
   AUTH_MAIL_RES_ERR: `인증메일 전송에 실패했습니다. 잠시 후 다시 시도해주세요. `,
-  NOT_VALID_PAGE_EXPIRE_TOKEN: `인증 링크가 유효하지 않습니다. 주소를 확인하거나 다시 회원가입을 진행해주세요.`, // 403
+  NOT_VALID_PAGE_EXPIRE_TOKEN: `인증 링크가 유효하지 않습니다.|주소를 확인하거나 다시 회원가입을 진행해주세요.`, // 403
 };
 
 const REDIS = {

--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -146,7 +146,8 @@ const kakaoGetData = async (req, res) => {
  */
 const authEmail = async (req, res) => {
   try {
-    const params = await authService.authEmailTokenVerify(req.url);
+    const token = req.body['token'];
+    const params = await authService.authEmailTokenVerify(token);
     sendResponse(res, StatusCodes.OK, {}, '이메일 인증에 성공했습니다.');
   } catch (err) {
     throw err;

--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -133,6 +133,7 @@ const authEmail = async (req, res) => {
  */
 const loginByEmail = async (req, res) => {
   try {
+    req.session.userId = req.body;
     const token = await authService.userLogin(req.body);
     sendResponse(res, StatusCodes.OK, token, '로그인 성공');
   } catch (err) {

--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -1,8 +1,11 @@
 const { authService } = require('../services');
 const { StatusCodes } = require('http-status-codes');
 const { sendResponse } = require('../utils/responses/responseHandler');
+const { userService } = require('../services');
+const kakaoAPI = require('../integrations/kakaoAPI');
 const kakaoStrategy1 = require('../config/passport/kakaoStrategy1');
 const passport = require('passport');
+const url = require('url');
 
 const kakaoLoginCallback = async (req, res, next) => {
   // const clientIp = req.headers['x-forwarded-for'] || req.connection.remoteAddress;
@@ -111,6 +114,31 @@ const kakaoLoginCallback = async (req, res, next) => {
   // };
 };
 
+const kakaoGetData = async (req, res) => {
+  const authCode = url.parse(req.url, true).query['code'];
+  console.log(`카카오 인가코드 : ${authCode}`);
+
+  try {
+    const kakaoToken = await kakaoAPI.fetchKakaoToken(authCode);
+    const user = await kakaoAPI.fetchKakaoUserInfo(kakaoToken);
+    console.log(user.id);
+    const userInfo = await userService.findUserByKakao(user.id);
+
+    // 유저 정보가 존재하지 않는 경우
+    if (!userInfo) {
+      req.session.kakaoId = user.id;
+      sendResponse(
+        res,
+        StatusCodes.MOVED_PERMANENTLY,
+        { url: '/login' },
+        `카카오 계정 연동을 위해 가입하신 메일로 로그인 해주세요. \n 만약 처음이시라면 이메일 회원가입 후 이용해주세요.`,
+      );
+    }
+  } catch (err) {
+    throw err;
+  }
+};
+
 /**
  * 유저 이메일 인증 상태 변경
  *
@@ -144,4 +172,5 @@ module.exports = {
   kakaoLoginCallback,
   authEmail,
   loginByEmail,
+  kakaoGetData,
 };

--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -121,7 +121,6 @@ const kakaoGetData = async (req, res) => {
   try {
     const kakaoToken = await kakaoAPI.fetchKakaoToken(authCode);
     const user = await kakaoAPI.fetchKakaoUserInfo(kakaoToken);
-    console.log(user.id);
     const userInfo = await userService.findUserByKakao(user.id);
 
     // 유저 정보가 존재하지 않는 경우
@@ -161,9 +160,18 @@ const authEmail = async (req, res) => {
  */
 const loginByEmail = async (req, res) => {
   try {
-    req.session.userId = req.body;
-    const token = await authService.userLogin(req.body);
-    sendResponse(res, StatusCodes.OK, token, '로그인 성공');
+    const kakaoId = req.session.kakaoId;
+    const data = {
+      ...req.body,
+      kakaoId,
+    };
+    const result = await authService.userLogin(data);
+    if (result.accessToken) {
+      sendResponse(res, StatusCodes.OK, { token: result.accessToken }, '로그인 성공');
+    } else {
+      sendResponse(res, StatusCodes.MOVED_PERMANENTLY, { url: '/login' }, result.message);
+    }
+    await delete rea.session.kakaoId;
   } catch (err) {
     throw err;
   }

--- a/src/controllers/user.controller.js
+++ b/src/controllers/user.controller.js
@@ -14,7 +14,16 @@ const { StatusCodes } = require('http-status-codes');
  */
 const createUserByEmail = async (req, res) => {
   try {
-    const createUser = await userService.createUserEmail(req.body);
+    const kakaoId = req.session.kakaoId;
+    const data = {
+      ...req.body,
+      kakaoId,
+    };
+
+    const createUser = await userService.createUserEmail(data);
+
+    // 세션 데이터 사용 후 삭제
+    await delete req.session.kakaoId;
     sendResponse(res, StatusCodes.OK, {}, '가입이 완료되었습니다. 가입하신 메일을 확인하여 인증을 진행해주세요.');
   } catch (err) {
     throw err;

--- a/src/controllers/user.controller.js
+++ b/src/controllers/user.controller.js
@@ -16,7 +16,6 @@ const createUserByEmail = async (req, res) => {
   try {
     const createUser = await userService.createUserEmail(req.body);
     sendResponse(res, StatusCodes.OK, {}, '가입이 완료되었습니다. 가입하신 메일을 확인하여 인증을 진행해주세요.');
-    res.status(StatusCodes.OK).json({ data: true, message: '' });
   } catch (err) {
     throw err;
   }

--- a/src/integrations/kakaoAPI.js
+++ b/src/integrations/kakaoAPI.js
@@ -1,0 +1,56 @@
+require('dotenv').config();
+const axios = require('axios');
+const logger = require('../config/logger');
+
+/**
+ * 클라이언트에게 전달받은 인가 코드를 사용하여 카카오 액세스 토큰 가져오기
+ * @param {String} authCode - 카카오 인가 코드
+ * @returns {String} 카카오 액세스 토큰
+ */
+const fetchKakaoToken = async (authCode) => {
+  const functionName = 'fetchKakaoToken';
+  try {
+    logger.info(`starting ${functionName} in kakaoAPI`);
+    const response = await axios({
+      method: 'POST',
+      url: 'https://kauth.kakao.com/oauth/token',
+      headers: {
+        'Content-type': 'application/json',
+      },
+      params: {
+        grant_type: 'authorization_code',
+        client_id: process.env.KAKAO_CLIENT_ID,
+        client_secret: 'yyamppli',
+        code: authCode,
+      },
+    });
+    return response.data.access_token;
+  } catch (err) {
+    throw new Error('카카오 인가코드를 가져오는데 실패했습니다.');
+  }
+};
+
+/**
+ * 액세스 토큰을 사용하여 카카오에 등록된 유저 정보 가져오기
+ * @param {String} token - 액세스 토큰
+ * @returns {Object} 카카오 유저 정보
+ */
+const fetchKakaoUserInfo = async (token) => {
+  const functionName = 'fetchKakaoUserInfo';
+  try {
+    logger.info(`starting ${functionName} in kakaoAPI`);
+    const response = await axios.get('https://kapi.kakao.com/v2/user/me', {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+    return response.data;
+  } catch (err) {
+    throw new Error(`액세스 토큰을 사용하여 유저 정보를 가져오는데 실패했습니다.`);
+  }
+};
+
+module.exports = {
+  fetchKakaoToken,
+  fetchKakaoUserInfo,
+};

--- a/src/models/user.model.js
+++ b/src/models/user.model.js
@@ -5,7 +5,7 @@ const userSchema = mongoose.Schema({
   email: { type: String, required: true, lowercase: true, unique: true },
   password: { type: String, required: true },
   nickname: { type: String, minLength: 1, maxLength: 100, required: true },
-  kakaoId: { type: String, unique: true, sparse: true }, // sparse : 유니크 필드 null 중복 허용
+  kakaoId: { type: String, unique: true, sparse: true, default: null }, // sparse : 유니크 필드 null 중복 허용
   createdAt: { type: Date, default: Date.now }, // 작성 시간을 저장하는 필드 추가
   isActive: { type: Boolean, default: true },
   emailAuth: { type: Boolean, default: false },

--- a/src/services/auth.service.js
+++ b/src/services/auth.service.js
@@ -18,23 +18,25 @@ const authEmailTokenVerify = async (url) => {
   logger.info(`starting ${functionName} in authService`);
   try {
     const email = await redisClient.getNamespacedData('0', queryParams);
+    const user = await userService.findUserByEmail(email);
 
-    if (!email) {
+    // 레디스 데이터 유효시간 초과 혹은 유저 데이터 없는 경우 인증 코드 유효x 알림
+    if (!email || !user) {
       logger.error(STRINGS.ALERT.NOT_VALID_PAGE_EXPIRE_TOKEN);
       throw new ForbiddenError(STRINGS.ALERT.NOT_VALID_PAGE_EXPIRE_TOKEN);
     }
-
-    const user = await userService.findUserByEmail(email);
-
-    if (!user && user.emailAuth) {
+    // 인증 완료된 데이터 존재 -> 이미 발송된 메일 무효화
+    if (user && user.emailAuth) {
       logger.error(STRINGS.ALERT.CHECK_SIGN_EMAIL);
       throw new ConflictError(STRINGS.ALERT.CHECK_SIGN_EMAIL);
     }
     user.emailAuth = true;
     await user.save();
-    await redisClient.delNamespacedData('0', queryParams);
   } catch (err) {
     throw err;
+  } finally {
+    // 완료 시 , 만료된 링크 선택 시 레디스에 저장된 데이터 삭제
+    await redisClient.delNamespacedData('0', queryParams);
   }
 };
 

--- a/src/services/auth.service.js
+++ b/src/services/auth.service.js
@@ -11,13 +11,12 @@ const logger = require('../config/logger');
  * @param {String} url 이메일 인증 URL
  * @returns {Boolean}
  */
-const authEmailTokenVerify = async (url) => {
+const authEmailTokenVerify = async (token) => {
   const functionName = `authEmailTokenVerify`;
-  const queryParams = extractQueryParams(url).token;
 
   logger.info(`starting ${functionName} in authService`);
   try {
-    const email = await redisClient.getNamespacedData('0', queryParams);
+    const email = await redisClient.getNamespacedData('0', token);
     const user = await userService.findUserByEmail(email);
 
     // 레디스 데이터 유효시간 초과 혹은 유저 데이터 없는 경우 인증 코드 유효x 알림
@@ -36,7 +35,7 @@ const authEmailTokenVerify = async (url) => {
     throw err;
   } finally {
     // 완료 시 , 만료된 링크 선택 시 레디스에 저장된 데이터 삭제
-    await redisClient.delNamespacedData('0', queryParams);
+    await redisClient.delNamespacedData('0', token);
   }
 };
 
@@ -60,7 +59,7 @@ const userLogin = async (payload) => {
     if (user && (await user.isPasswordMatch(password))) {
       const { accessToken, refreshToken } = await jwtService.createToken(user);
       await redisClient.setNamespacedData('0', email, refreshToken);
-      return {accessToken};
+      return { accessToken };
     } else {
       logger.error(`아이디/패스워드와 일치하는 사용자가 없습니다.`);
       throw new ConflictError('아이디/패스워드와 일치하는 사용자가 없습니다.\n 확인하시고 다시 시도해주세요.');

--- a/src/services/user.service.js
+++ b/src/services/user.service.js
@@ -118,7 +118,7 @@ const createUserEmail = async (userData) => {
     // 일회용 토큰 생성
     const token = crypto.randomBytes(32).toString('hex');
 
-    await redisClient.setNamespacedData('0', token, email, 3600);
+    await redisClient.setNamespacedData('0', token, email, 300);
     const verificationLink = `${process.env.SERVER_URL}/auth/auth-email?token=${token}`;
     await sendAuthMail(email, verificationLink);
 
@@ -135,6 +135,11 @@ const createUserEmail = async (userData) => {
  */
 const findUserByEmail = async (email) => {
   const user = await User.findOne({ email: email });
+  return user;
+};
+
+const findUserByKakao = async (kakaoId) => {
+  const user = await User.findOne({ kakaoId: kakaoId });
   return user;
 };
 
@@ -261,7 +266,7 @@ module.exports = {
   deleteUserAndRelatedData,
   createUserEmail,
   verifyJWT,
-
   findUserByEmail,
   emailAuthCheck,
+  findUserByKakao,
 };

--- a/src/services/user.service.js
+++ b/src/services/user.service.js
@@ -89,13 +89,15 @@ const findNickname = async (nickname) => {
 /**
  * 유저 데이터 생성
  * 이미 등록되고 미인증 유저인 경우 새롭게 입력된 데이터로 업데이트
+ * 세션에서 가져온 카카오 아이디를 확인하여 이메일 계정과 연동
  *
  * @param {Object} userData
  * @returns {Promise<User>}
  */
 const createUserEmail = async (userData) => {
   const functionName = `createUserEmail`;
-  const { email, password } = userData;
+  // 세션에 저장된 카카오 아이디 사용(카카오 연동)
+  const { email, password, kakaoId } = userData;
   const getUser = await findUserByEmail(email);
   let user;
   logger.info(`starting ${functionName} in userService.js`);
@@ -106,12 +108,16 @@ const createUserEmail = async (userData) => {
   if (getUser) {
     getUser.password = password;
     getUser.nickname = createNickname();
+    if (kakaoId) {
+      getUser.kakaoId = kakaoId;
+    }
     user = await getUser.save();
   } else {
     user = await User.create({
       email: email,
       password: password,
       nickname: createNickname(),
+      kakaoId: kakaoId || null,
     });
   }
   try {

--- a/src/services/user.service.js
+++ b/src/services/user.service.js
@@ -125,7 +125,7 @@ const createUserEmail = async (userData) => {
     const token = crypto.randomBytes(32).toString('hex');
 
     await redisClient.setNamespacedData('0', token, email, 300);
-    const verificationLink = `${process.env.SERVER_URL}/auth/auth-email?token=${token}`;
+    const verificationLink = `${process.env.CLIENT_URL}/verify-email?token=${token}`;
     await sendAuthMail(email, verificationLink);
 
     return true;

--- a/src/services/user.service.js
+++ b/src/services/user.service.js
@@ -118,19 +118,13 @@ const createUserEmail = async (userData) => {
     // 일회용 토큰 생성
     const token = crypto.randomBytes(32).toString('hex');
 
-    await redisClient.clientConnect();
-    await redisClient.selectDataBase(0);
-    await redisClient.setData(token, email, 3600);
-
+    await redisClient.setNamespacedData('0', token, email, 3600);
     const verificationLink = `${process.env.SERVER_URL}/auth/auth-email?token=${token}`;
     await sendAuthMail(email, verificationLink);
 
     return true;
   } catch (err) {
     throw err;
-  } finally {
-    // 레디스 클라이언트가 연결된 상태인지 확인
-    await redisClient.disconnect();
   }
 };
 

--- a/src/utils/responses/responseHandler.js
+++ b/src/utils/responses/responseHandler.js
@@ -1,7 +1,12 @@
 const { StatusCodes } = require('http-status-codes');
 
 const sendResponse = (res, statusCode = StatusCodes.OK, data = {}, message = '') => {
-  return res.status(statusCode).json({ success: true, data, message });
+  const code = statusCode.toString();
+  let success = true;
+  if (code[0] != '2') {
+    success = false;
+  }
+  return res.status(statusCode).json({ success, data, message });
 };
 
 module.exports = { sendResponse };


### PR DESCRIPTION
## 개요
- 가입된 메일로 이메일 인증 관련 링크 전달 시 기존에 API 주소를 전달하여 서버로 직접 요청하는 방식에서, 클라이언트 주소를 전달하여 클라이언트에서 토큰을 추출하고 서버로 요청하는 방식으로 수정
## 작업사항
- 인증 링크 생성 시 클리이언트 URL을 사용하여 생성
- 서버에서 클라이언트가 전달한 토큰 값을 받아서 사용하기 위해 post 메서드로 라우터 수정
- 컨트롤러에서 request 객체에서 토큰을 가져와서 서비스 계층으로 전달
- 기존에 서비스 계층에서 매개변수로 url을 받은 후 파라미터를 추출하는 과정을 토큰을 받은후 곧바로 레디스 저장소에서 이메일을 찾아오도록 수정
## 테스트
### 이메일 인증 전
<img width="302" alt="이메일인증전_데이터그립" src="https://github.com/YAMPLI/yampli_server/assets/51108221/ad2cc233-0561-4ca9-8a2e-a97de0c8fe7f">

### 인증 성공 확인(클라이언트)
<img width="302" alt="인증성공알람" src="https://github.com/YAMPLI/yampli_server/assets/51108221/3c6c8173-37e6-43e7-ac7e-2fa111215df5">

### 이메일 인증 후
<img width="302" alt="이메일인증후_데이터그립" src="https://github.com/YAMPLI/yampli_server/assets/51108221/eefd0cae-9ef3-4ae6-ba69-3fc4b2fdde31">

close #33 